### PR TITLE
Basic support for new login method.

### DIFF
--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -9,8 +9,8 @@ from routeros_api import exceptions
 from routeros_api import resource
 
 
-def connect(host, username='admin', password='', port=None, insecure_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
-    return RouterOsApiPool(host, username, password, port, insecure_login, use_ssl, ssl_verify, ssl_verify_hostname, ssl_context).get_api()
+def connect(host, username='admin', password='', port=None, plaintext_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
+    return RouterOsApiPool(host, username, password, port, plaintext_login, use_ssl, ssl_verify, ssl_verify_hostname, ssl_context).get_api()
 
 
 class RouterOsApiPool(object):

--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -16,12 +16,12 @@ def connect(host, username='admin', password='', port=None, insecure_login=False
 class RouterOsApiPool(object):
     socket_timeout = 15.0
 
-    def __init__(self, host, username='admin', password='', port=None, insecure_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
+    def __init__(self, host, username='admin', password='', port=None, plaintext_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
         self.host = host
         self.username = username
         self.password = password
-        # Don't send the new-style login (can expose password in plaintext!)
-        self.insecure_login = insecure_login
+
+        self.plaintext_login = plaintext_login
 
         self.ssl_context = ssl_context
         # Use SSL? Ignored when using a context, so we will set it for simple reference when port-switching:
@@ -48,7 +48,7 @@ class RouterOsApiPool(object):
             self.api = RouterOsApi(communicator)
             for handler in self._get_exception_handlers():
                 communicator.add_exception_handler(handler)
-            self.api.login(self.username, self.password, self.insecure_login)
+            self.api.login(self.username, self.password, self.plaintext_login)
             self.connected = True
         return self.api
 
@@ -76,9 +76,9 @@ class RouterOsApi(object):
     def __init__(self, communicator):
         self.communicator = communicator
 
-    def login(self, login, password, insecure_login):
+    def login(self, login, password, plaintext_login):
         response = None
-        if insecure_login:
+        if plaintext_login:
             response = self.get_binary_resource('/').call('login',{ 'name': login, 'password': password })
         else:
             response = self.get_binary_resource('/').call('login')

--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -32,7 +32,7 @@ class RouterOsApiPool(object):
         self.ssl_verify = ssl_verify
         self.ssl_verify_hostname = ssl_verify_hostname
 
-        self.port = port or self._select_default_port(use_ssl)
+        self.port = port or self._select_default_port(self.use_ssl)
 
         self.connected = False
         self.socket = api_socket.DummySocket()

--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -9,20 +9,31 @@ from routeros_api import exceptions
 from routeros_api import resource
 
 
-def connect(host, username='admin', password='', port=8728, insecure_login=False):
-    return RouterOsApiPool(host, username, password, port, insecure_login).get_api()
+def connect(host, username='admin', password='', port=None, insecure_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
+    return RouterOsApiPool(host, username, password, port, insecure_login, use_ssl, ssl_verify, ssl_verify_hostname, ssl_context).get_api()
 
 
 class RouterOsApiPool(object):
-    socket_timeout = 15.
+    socket_timeout = 15.0
 
-    def __init__(self, host, username='admin', password='', port=8728, insecure_login=False):
+    def __init__(self, host, username='admin', password='', port=None, insecure_login=False, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None):
         self.host = host
         self.username = username
         self.password = password
-        self.port = port
         # Don't send the new-style login (can expose password in plaintext!)
         self.insecure_login = insecure_login
+
+        self.ssl_context = ssl_context
+        # Use SSL? Ignored when using a context, so we will set it for simple reference when port-switching:
+        if ssl_context is not None:
+            self.use_ssl = True
+        else:
+            self.use_ssl = use_ssl
+        self.ssl_verify = ssl_verify
+        self.ssl_verify_hostname = ssl_verify_hostname
+
+        self.port = port or self._select_default_port(use_ssl)
+
         self.connected = False
         self.socket = api_socket.DummySocket()
         self.communication_exception_parser = (
@@ -31,7 +42,7 @@ class RouterOsApiPool(object):
     def get_api(self):
         if not self.connected:
             self.socket = api_socket.get_socket(self.host, self.port,
-                                                timeout=self.socket_timeout)
+                                                timeout=self.socket_timeout, use_ssl=self.use_ssl, ssl_verify=self.ssl_verify, ssl_verify_hostname=self.ssl_verify_hostname, ssl_context=self.ssl_context)
             base = base_api.Connection(self.socket)
             communicator = api_communicator.ApiCommunicator(base)
             self.api = RouterOsApi(communicator)
@@ -53,6 +64,12 @@ class RouterOsApiPool(object):
     def _get_exception_handlers(self):
         yield CloseConnectionExceptionHandler(self)
         yield self.communication_exception_parser
+
+    def _select_default_port(self, use_ssl):
+        if use_ssl:
+            return 8729
+        else:
+            return 8728
 
 
 class RouterOsApi(object):


### PR DESCRIPTION
Some basic support for the new post-v6.43 login method. As suggested by the community, it attempts to use the new method and falls back to the old one in case of getting a challenge response. I have added an option for forcing the old login method, since there are many cases where it is undesirable to send the password in plain-text over the Internet. I would recommend always using SSL when using this new login.