### PR TITLE
Support Login API V 6.43

### DIFF
--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -58,15 +58,22 @@ class RouterOsApi(object):
         self.communicator = communicator
 
     def login(self, login, password):
-        response = self.get_binary_resource('/').call('login')
-        token = binascii.unhexlify(response.done_message['ret'])
-        hasher = hashlib.md5()
-        hasher.update(b'\x00')
-        hasher.update(password.encode())
-        hasher.update(token)
-        hashed = b'00' + hasher.hexdigest().encode('ascii')
-        self.get_binary_resource('/').call(
-            'login', {'name': login.encode(), 'response': hashed})
+        try:
+            #Default Old_login < 6.42
+            response = self.get_binary_resource('/').call('login')
+            token = binascii.unhexlify(response.done_message['ret'])
+            hasher = hashlib.md5()
+            hasher.update(b'\x00')
+            hasher.update(password.encode())
+            hasher.update(token)
+            hashed = b'00' + hasher.hexdigest().encode('ascii')
+            #assert False
+            self.get_binary_resource('/').call(
+                'login', {'name': login.encode(), 'response': hashed})
+
+        except exceptions.RouterOsApiCommunicationError:
+            #New Login >6.43
+            response = self.get_binary_resource('/').call('login', {'name': login, 'password': password})
 
     def get_resource(self, path, structure=None):
         structure = structure or api_structure.default_structure


### PR DESCRIPTION
Hi, 

By default it initiates session with the previous login, if it fails then it tries with the new login v6.43
I did this to avoid sending version in def connect, because that way I would not change anything in my project

How Test?
Upgrade your RB with 6.43rc21   https://download.mikrotik.com/routeros/6.43rc32/routeros-mipsbe-6.43rc21.npk

Issue #29 

In new updates like v 6.43RC32 works with the previous login.
Regards
