### PR TITLE
Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+dist: xenial
 language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install mock
   - pip install six

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
 install:
   - pip install mock

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
 )


### PR DESCRIPTION
- Dropped old (EOL) Python versions:
  - 2.6
  - 3.3
- Add support for new Python versions:
  - 3.5
  - 3.6
  - 3.7