### PR TITLE
Fix: encode username and password if necessary for plaintext login method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for RouterOS-api
 0.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix bug with plain text login using string credentials ([#47](https://github.com/socialwifi/RouterOS-api/issues/47))
 
 
 0.15.0 (2018-08-23)

--- a/routeros_api/api.py
+++ b/routeros_api/api.py
@@ -1,5 +1,6 @@
 import hashlib
 import binascii
+from six import string_types
 from routeros_api import api_communicator
 from routeros_api import communication_exception_parsers
 from routeros_api import api_socket
@@ -79,6 +80,10 @@ class RouterOsApi(object):
     def login(self, login, password, plaintext_login):
         response = None
         if plaintext_login:
+            if isinstance(login, string_types):
+                login = login.encode()
+            if isinstance(password, string_types):
+                password = password.encode()
             response = self.get_binary_resource('/').call('login',{ 'name': login, 'password': password })
         else:
             response = self.get_binary_resource('/').call('login')

--- a/tests/test_login_router_os_api.py
+++ b/tests/test_login_router_os_api.py
@@ -1,0 +1,32 @@
+import unittest
+
+from routeros_api import api
+from routeros_api import api_communicator
+from routeros_api import base_api
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class TestLoginRouterOsApi(unittest.TestCase):
+    def get_api(self):
+        socket = mock.MagicMock()
+        base = base_api.Connection(socket)
+        base.receive_sentence = mock.Mock(return_value=[b'!done', b'.tag=1'])
+        communicator = api_communicator.ApiCommunicator(base)
+        routeros_api = api.RouterOsApi(communicator)
+        return routeros_api
+
+    def test_login(self):
+        routeros_api = self.get_api()
+        routeros_api.login('admin', 'password123', plaintext_login=False)
+
+    def test_plain_text_login(self):
+        routeros_api = self.get_api()
+        routeros_api.login('admin', 'password123', plaintext_login=True)
+
+    def test_plain_text_login_with_bytes(self):
+        routeros_api = self.get_api()
+        routeros_api.login(b'admin', b'password123', plaintext_login=True)


### PR DESCRIPTION
The problem was in plain text login method: username and password was not encoded to bytes when `plaintext_login=True`. I'm leaving check if string type is provided due to some people may already using bytes to fix the problem on his own.

Proper solution of: https://github.com/socialwifi/RouterOS-api/pull/48 ,  https://github.com/socialwifi/RouterOS-api/pull/46

Resolves: https://github.com/socialwifi/RouterOS-api/issues/47