### PR TITLE
Update api_structure.py

### DIFF
--- a/routeros_api/api_structure.py
+++ b/routeros_api/api_structure.py
@@ -28,7 +28,7 @@ class StringField(Field):
         return string.encode()
 
     def get_python_value(self, bytes):
-        return bytes.decode()
+        return bytes.decode('cp1251')
 
 
 class BytesField(Field):


### PR DESCRIPTION
Fix for non-ascii chacacters in mikrotik config

File "home\user\.env\lib\site-packages\routeros_api\api_structure.py", line 31, in get_python_value
    return bytes.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8f in position 6: invalid start byte