### PR TITLE
Allow query without value

### DIFF
--- a/routeros_api/sentence.py
+++ b/routeros_api/sentence.py
@@ -56,7 +56,11 @@ class CommandSentence(object):
     def get_api_format(self):
         formated = [self.path + self.command]
         for key, value in self.attributes.items():
-            formated.append(b'=' + key + b'=' + value)
+            if value == None:
+                formated.append(b'=' + key)
+            else:
+                formated.append(b'=' + key + b'=' + value)
+
         for query in self.queries:
             formated.extend(query.get_api_format())
         if self.tag is not None:


### PR DESCRIPTION
Patch is to allow queries with parameters without values like:
`api.get_binary_resource('/system/gps').call('monitor', {'once':None} )
`
