### PR TITLE
Fix invalid escape sequence by using double backslashes

### DIFF
--- a/routeros_api/sentence.py
+++ b/routeros_api/sentence.py
@@ -6,7 +6,7 @@ from routeros_api import query
 
 response_re = re.compile(b'^!(re|trap|fatal|done)$')
 attribute_re = re.compile(b'^=([^=]+)=(.*)$', re.DOTALL)
-tag_re = re.compile(b'^\.tag=(.*)$')
+tag_re = re.compile(b'^\\.tag=(.*)$')
 
 
 class ResponseSentence(object):


### PR DESCRIPTION
```
==> Starting package()...
/usr/lib/python3.12/site-packages/routeros_api/sentence.py:9: SyntaxWarning: invalid escape sequence '\.' 
/usr/lib/python3.12/site-packages/routeros_api/sentence.py:9: SyntaxWarning: invalid escape sequence '\.'
```