### PR TITLE
Add support for RouterOS 7.18's `!empty` reply word

### DIFF
--- a/routeros_api/sentence.py
+++ b/routeros_api/sentence.py
@@ -3,7 +3,7 @@ import re
 from routeros_api import exceptions
 from routeros_api import query
 
-response_re = re.compile(rb'^!(re|trap|fatal|done)$')
+response_re = re.compile(rb'^!(re|trap|fatal|empty|done)$')
 attribute_re = re.compile(rb'^=([^=]+)=(.*)$', re.DOTALL)
 tag_re = re.compile(rb'^\.tag=(.*)$')
 

--- a/tests/test_api_communicator.py
+++ b/tests/test_api_communicator.py
@@ -49,6 +49,14 @@ class TestCommunicator(TestCase):
         self.assertRaises(exceptions.RouterOsApiCommunicationError,
                           promise.get)
 
+    def test_empty_call(self):
+        base = mock.Mock()
+        base.receive_sentence.side_effect = [[b'!empty', b'.tag=1'],
+                                             [b'!done', b'.tag=1']]
+        communicator = api_communicator.ApiCommunicator(base)
+        response = communicator.call('/file/', 'print').get()
+        self.assertEqual(response, [])
+
     def test_query_call(self):
         base = mock.Mock()
         base.receive_sentence.return_value = [b'!done', b'.tag=1']


### PR DESCRIPTION
See documentation at https://help.mikrotik.com/docs/spaces/ROS/pages/47579160/API#API-Replyword

Fixes #102